### PR TITLE
docs fixes, and rename an abc

### DIFF
--- a/gcdyn/mutators.py
+++ b/gcdyn/mutators.py
@@ -52,7 +52,7 @@ class Mutator(ABC):
 
 
 class AttrMutator(Mutator):
-    r"""Abstract base class for mutators that mutate a specifie
+    r"""Abstract base class for mutators that mutate a specified
     :py:class:`ete3.TreeNode` node attribute.
 
     Args:


### PR DESCRIPTION
Minor changes in mutators module to fix docs formatting and rename an abstract base class that has been generalized.